### PR TITLE
feat: merge-default-graph command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Image for building the project
-FROM rust:bookworm
+FROM docker.io/rust:bookworm
 # 1. create empty shell project
 RUN USER=root cargo new --bin app
 WORKDIR /app

--- a/src/common/pipe.rs
+++ b/src/common/pipe.rs
@@ -3,7 +3,7 @@ use clap::Parser;
 #[derive(clap::Subcommand, Clone, Debug)]
 #[command(
     subcommand_value_name = "PIPELINE",
-    subcommand_help_heading = "Pineline",
+    subcommand_help_heading = "Pipeline",
     disable_help_subcommand = true
 )]
 pub enum PipeSubcommand {

--- a/src/common/pipe.rs
+++ b/src/common/pipe.rs
@@ -13,7 +13,7 @@ pub enum PipeSubcommand {
     // Pipe(Box<crate::SinkSubcommand>)
 
     // // NB: instead, we defer the parsing of the piped command
-    /// Optionanally pipe quads to another subcommand
+    /// Optionally pipe quads to another subcommand
     #[command(name = "!")]
     Pipe(PipeArgs),
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ use sophia::api::source::QuadSource;
 
 mod canonicalize;
 mod common;
+mod merge_default_graph;
 mod parse;
 mod serialize;
 
@@ -42,6 +43,8 @@ enum SinkSubcommand {
     Canonicalize(canonicalize::Args),
     #[command(visible_aliases=["s"], aliases=["se", "ser"])]
     Serialize(serialize::Args),
+    #[command(visible_aliases=["m"], aliases=["me", "mer"])]
+    MergeDefaultGraph(merge_default_graph::Args),
 }
 
 impl SinkSubcommand {
@@ -52,6 +55,7 @@ impl SinkSubcommand {
         match self {
             Self::Canonicalize(args) => canonicalize::run(quads, args),
             Self::Serialize(args) => serialize::run(quads, args),
+            Self::MergeDefaultGraph(args) => merge_default_graph::run(quads, args),
         }
     }
 }

--- a/src/merge_default_graph.rs
+++ b/src/merge_default_graph.rs
@@ -1,0 +1,20 @@
+use anyhow::Result;
+use sophia::api::{quad::Quad, source::QuadSource};
+
+use crate::common::{pipe::PipeSubcommand, quad_handler::QuadHandler};
+
+/// Merge named graphs with the default graph
+#[derive(clap::Args, Clone, Debug)]
+pub struct Args {
+    #[command(subcommand)]
+    pipeline: Option<PipeSubcommand>,
+}
+
+pub fn run<Q: QuadSource>(quads: Q, args: Args) -> Result<()>
+where
+    <Q as QuadSource>::Error: Send + Sync,
+{
+    log::trace!("merge-default-graph args: {args:#?}");
+    let handler = QuadHandler::new(args.pipeline);
+    handler.handle_triples(quads.to_triples())
+}

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -102,18 +102,7 @@ where
     <S as TripleSerializer>::Error: Send + Sync,
 {
     let warned = AtomicBool::new(false);
-    let triples = quads
-        .filter_quads(|q| {
-            if q.g().is_some() {
-                if !warned.fetch_or(true, Ordering::Relaxed) {
-                    log::warn!("Named graphs are ignored when serializing to triples-only format.");
-                }
-                false
-            } else {
-                true
-            }
-        })
-        .to_triples();
+    let triples = quads.to_triples();
     match ser.serialize_triples(triples) {
         Ok(_) => Ok(()),
         Err(SourceError(e)) => Err(e).with_context(|| "Error in incoming triples"),

--- a/src/serialize.rs
+++ b/src/serialize.rs
@@ -102,7 +102,18 @@ where
     <S as TripleSerializer>::Error: Send + Sync,
 {
     let warned = AtomicBool::new(false);
-    let triples = quads.to_triples();
+    let triples = quads
+        .filter_quads(|q| {
+            if q.g().is_some() {
+                if !warned.fetch_or(true, Ordering::Relaxed) {
+                    log::warn!("Named graphs are ignored when serializing to triples-only format.");
+                }
+                false
+            } else {
+                true
+            }
+        })
+        .to_triples();
     match ser.serialize_triples(triples) {
         Ok(_) => Ok(()),
         Err(SourceError(e)) => Err(e).with_context(|| "Error in incoming triples"),


### PR DESCRIPTION
Thanks for the great tool! I've been looking for a high performance RDF CLI for a while and sop seems very intuitive :+1: 

**Context:**
sop currently drops all named graphs when converting quads to triples. There are cases where one may want to "unwrap" those triples and discard the context.

**Changes:**
This PR alters the behavior of sop to reproduce that of rdfpipe when casting quads to triples.

**Question**
I understand, one may not want/expect this to be the default behaviour (as currently sop behaves like jena riot):
Would it make sense to have some CLI option in `serialize` to enable this behavior? Alternatively, this could be a separate sink command. I would be curious to know your opinion and I could give a try at implementing it.
